### PR TITLE
Gradle 설정 및 의존성 버전 중앙 관리 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.10'
-    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
     id 'jacoco'
-    id "org.asciidoctor.jvm.convert" version "3.3.2" // (1) plugin 추가
+    id "org.asciidoctor.jvm.convert" version "${asciidoctorConvertVersion}" // (1) plugin 추가
 }
 
-group = 'com'
-version = '0.0.1-SNAPSHOT'
+group = projectGroup
+version = applicationVersion
 
 java {
-    sourceCompatibility = '11'
+    sourceCompatibility = JavaVersion.toVersion(javaVersion)
 }
 
 configurations {
@@ -34,7 +34,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation "io.rest-assured:rest-assured:${restAssuredVersion}"
 
     //테스트에서 lombok 사용
     testCompileOnly 'org.projectlombok:lombok'
@@ -44,14 +44,14 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // h2
+    // h2, mysql
     runtimeOnly 'com.h2database:h2'
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly "com.mysql:mysql-connector-j:${mysqlConnectorVersion}"
 
     // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
 
     // spring restdocs (3), (4)
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 applicationVersion=2.0.1-SNAPSHOT
 
 ### Project configs ###
-projectGroup=com
+projectGroup=com.hibitbackendimproved
 javaVersion=11
 
 ### Spring dependency versions ###

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,19 @@
+### Application version ###
+applicationVersion=2.0.1-SNAPSHOT
+
+### Project configs ###
+projectGroup=com
+javaVersion=11
+
+### Spring dependency versions ###
+springBootVersion=2.7.1
+springDependencyManagementVersion=1.0.15.RELEASE
+
+### Plugin versions ###
+jacocoVersion=0.8.7
+asciidoctorConvertVersion=3.3.2
+
+### Dependency versions ###
+mysqlConnectorVersion=8.0.33
+restAssuredVersion=4.4.0
+jjwtVersion=0.11.5

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,11 @@
+
+
+pluginManagement {
+    plugins {
+        id 'org.springframework.boot' version "${springBootVersion}"
+        id 'io.spring.dependency-management' version "${springDependencyManagementVersion}"
+    }
+}
+
+
 rootProject.name = 'hibit-backend-improved'


### PR DESCRIPTION
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feature`, `refactor`

## 작업 내용

Gradle 설정을 보다 명확하고 유지보수하기 쉽게 관리하기 위해, 
기존 `build.gradle`에 분산되어 있던 플러그인 및 라이브러리 버전 정보를 `gradle.properties`로 분리했습니다.

또한 `settings.gradle`을 통해 플러그인 버전 관리를 일원화했습니다.

이러한 변경을 통해 의존성 및 빌드 설정의 관리 일관성이 향상되었고,
추후 버전 업그레이드나 모듈 확장 시에도 보다 효율적으로 대응할 수 있는 구조로 변경했습니다.